### PR TITLE
openapi-types-ghec

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 16
           cache: npm
-      - run: npm install @octokit/openapi -D
+      - run: npm install @octokit/openapi-types-ghec -D
       - run: npm ci
       - run: npm run update-all
         if: >-

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@actions/artifact": "^1.1.0",
-        "@octokit/openapi-types": "^13.12.0",
+        "@octokit/openapi-types-ghec": "^14.0.0",
         "@octokit/rest": "^19.0.4",
         "@types/express": "^4.17.13",
         "@types/fs-extra": "^9.0.13",
@@ -1367,6 +1367,12 @@
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.12.0.tgz",
       "integrity": "sha512-1QYzZrwnn3rTQE7ZoSxXrO8lhu0aIbac1c+qIPOPEaVXBWSaUyLV1x9yt4uDQOwmu6u5ywVS8OJgs+ErDLf6vQ==",
+      "dev": true
+    },
+    "node_modules/@octokit/openapi-types-ghec": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types-ghec/-/openapi-types-ghec-14.0.0.tgz",
+      "integrity": "sha512-xhd9oEvn2aroGn+sk09Ptx/76Y7aKU0EIgHukHPCU1+rGJreO36baEEk6k8ZPblieHNM39FcykJQmtDrETm0KA==",
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
@@ -8496,6 +8502,12 @@
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.12.0.tgz",
       "integrity": "sha512-1QYzZrwnn3rTQE7ZoSxXrO8lhu0aIbac1c+qIPOPEaVXBWSaUyLV1x9yt4uDQOwmu6u5ywVS8OJgs+ErDLf6vQ==",
+      "dev": true
+    },
+    "@octokit/openapi-types-ghec": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types-ghec/-/openapi-types-ghec-14.0.0.tgz",
+      "integrity": "sha512-xhd9oEvn2aroGn+sk09Ptx/76Y7aKU0EIgHukHPCU1+rGJreO36baEEk6k8ZPblieHNM39FcykJQmtDrETm0KA==",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "ISC",
   "devDependencies": {
     "@actions/artifact": "^1.1.0",
-    "@octokit/openapi-types": "^13.12.0",
+    "@octokit/openapi-types-ghec": "^14.0.0",
     "@octokit/rest": "^19.0.4",
     "@types/express": "^4.17.13",
     "@types/fs-extra": "^9.0.13",

--- a/src/moctokit/request/request-mocker.ts
+++ b/src/moctokit/request/request-mocker.ts
@@ -1,5 +1,5 @@
 import { MockRequestParameters } from "./request-mocker.types";
-import { paths } from "@octokit/openapi-types";
+import { paths } from "@octokit/openapi-types-ghec";
 import { MoctokitResponseMocker } from "../response/response-mocker";
 import { EndpointDetails } from "../../endpoint-mocker/endpoint-mocker.types";
 import { RequestMocker } from "../../endpoint-mocker/request/abstract-request-mocker";

--- a/src/moctokit/response/response-mocker.ts
+++ b/src/moctokit/response/response-mocker.ts
@@ -1,4 +1,4 @@
-import { paths } from "@octokit/openapi-types";
+import { paths } from "@octokit/openapi-types-ghec";
 import { ExtractMockResponse } from "./respone-mocker.types";
 import { ResponseMocker } from "../../endpoint-mocker/response/abstract-response-mocker";
 


### PR DESCRIPTION
Shift to `openapi-types-ghec` since `openapi-types` does not contain all the apis from the openapi spec